### PR TITLE
Modify byte stream tests to deal with calling peek() with a too long length

### DIFF
--- a/tests/byte_stream_capacity.cc
+++ b/tests/byte_stream_capacity.cc
@@ -68,6 +68,20 @@ int main() {
             test.execute(Peek{"at"});
         }
 
+        {
+            ByteStreamTestHarness test{"peek-len-larger-than-capacity", 2};
+
+            test.execute(Write{"hi"}.with_bytes_written(2));
+            test.execute(Peek{"hi", 3});
+        }
+
+        {
+            ByteStreamTestHarness test{"peek-len-larger-than-bytes-written", 2};
+
+            test.execute(Write{"h"}.with_bytes_written(1));
+            test.execute(Peek{"h", 2});
+        }
+
     } catch (const exception &e) {
         cerr << "Exception: " << e.what() << endl;
         return EXIT_FAILURE;

--- a/tests/byte_stream_test_harness.cc
+++ b/tests/byte_stream_test_harness.cc
@@ -173,10 +173,11 @@ void BytesRead::execute(ByteStream &bs) const {
 }
 
 // Peek
-Peek::Peek(const std::string &output) : _output(output) {}
+Peek::Peek(const std::string &output) : _output(output), _len(output.size()) {}
+Peek::Peek(const std::string &output, const size_t len) : _output(output), _len(len) {}
 std::string Peek::description() const { return "\"" + _output + "\" at the front of the stream"; }
 void Peek::execute(ByteStream &bs) const {
-    auto output = bs.peek_output(_output.size());
+    auto output = bs.peek_output(_len);
     if (output != _output) {
         throw ByteStreamExpectationViolation("Expected \"" + _output + "\" at the front of the stream, but found \"" +
                                              output + "\"");

--- a/tests/byte_stream_test_harness.hh
+++ b/tests/byte_stream_test_harness.hh
@@ -122,8 +122,10 @@ struct RemainingCapacity : public ByteStreamExpectation {
 
 struct Peek : public ByteStreamExpectation {
     std::string _output;
+    size_t _len;
 
     Peek(const std::string &output);
+    Peek(const std::string &output, const size_t len);
     std::string description() const override;
     void execute(ByteStream &) const override;
 };


### PR DESCRIPTION
Added tests for:
- if peek is called with a length larger than the capacity, then
it should return only what has been written
- if peek is called with a length larger than the number of bytes
written (but still smaller than the capacity), it should return
only what has been written

The latter test caused issues that I later had to fix in lab 3,
so hopefully these tests will help catch these issues earlier.