### PR TITLE
Added unit test for stream re-assembler to handle zero sized segment

### DIFF
--- a/tests/fsm_stream_reassembler_single.cc
+++ b/tests/fsm_stream_reassembler_single.cc
@@ -133,6 +133,7 @@ int main() {
 
             test.execute(SubmitSegment{"de", 3}.with_eof(true));
             test.execute(BytesAssembled(5));
+            test.execute(BytesAvailable{"abcde"});
             test.execute(AtEof{});
         }
     } catch (const exception &e) {

--- a/tests/fsm_stream_reassembler_single.cc
+++ b/tests/fsm_stream_reassembler_single.cc
@@ -117,6 +117,24 @@ int main() {
             test.execute(BytesAvailable{"abcdefgh"});
             test.execute(NotAtEof{});
         }
+
+        {
+            ReassemblerTestHarness test{8};
+
+            test.execute(SubmitSegment{"abc", 0});
+            test.execute(BytesAssembled(3));
+            test.execute(NotAtEof{});
+
+            // Stream re-assembler should ignore empty segments
+            // when they are outside the window.
+            test.execute(SubmitSegment{"", 6});
+            test.execute(BytesAssembled(3));
+            test.execute(NotAtEof{});
+
+            test.execute(SubmitSegment{"de", 3}.with_eof(true));
+            test.execute(BytesAssembled(5));
+            test.execute(AtEof{});
+        }
     } catch (const exception &e) {
         cerr << "Exception: " << e.what() << endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
Added a test to make sure stream reassembler handles zero sized
segments outside the window.

This can happen if a FIN gets dropped and we get an ack (empty segment)
after the FIN was sent.