### PR TITLE
Added unit test for segment with early seqno

### DIFF
--- a/tests/recv_window.cc
+++ b/tests/recv_window.cc
@@ -168,6 +168,16 @@ int main() {
             test.execute(SegmentArrives{}.with_seqno(isn + 3).with_data("cd").with_result(SegmentArrives::Result::OK));
         }
 
+        {
+            // Segment queued on early seqno.
+            size_t cap = 4;
+            uint32_t isn = 23452;
+            TCPReceiverTestHarness test{cap};
+            test.execute(SegmentArrives{}.with_syn().with_seqno(isn).with_result(SegmentArrives::Result::OK));
+            test.execute(SegmentArrives{}.with_seqno(isn).with_data("ab").with_result(SegmentArrives::Result::OK));
+            test.execute(ExpectTotalAssembledBytes{0});
+        }
+
     } catch (const exception &e) {
         cerr << e.what() << endl;
         return 1;


### PR DESCRIPTION
Added a unit test for lab2 to test for receiving a segment with an early seqno.

There was a bug in my `tcp_receiver` that wasn't detected until lab4. Hopefully this test help future students find similar bugs during lab2.

In lab4, `fsm_ack_rst_relaxed.cc` surfaced this bug in Test 1:
<img width="819" alt="Screen Shot 2020-10-24 at 3 05 38 PM" src="https://user-images.githubusercontent.com/8939148/97091531-74344a00-160a-11eb-8b7d-e00c3919a7c8.png">