### PR TITLE
Added unit test for ignoring an unacceptable ACK

### DIFF
--- a/tests/send_ack.cc
+++ b/tests/send_ack.cc
@@ -52,6 +52,18 @@ int main() {
             test.execute(ExpectNoSegment{});
         }
 
+        {
+            TCPConfig cfg;
+            WrappingInt32 isn(rd());
+            cfg.fixed_isn = isn;
+
+            TCPSenderTestHarness test{"Unacceptable ACK is ignored", cfg};
+            test.execute(ExpectState{TCPSenderStateSummary::SYN_SENT});
+            test.execute(ExpectSegment{}.with_no_flags().with_syn(true).with_payload_size(0).with_seqno(isn));
+            test.execute(AckReceived{WrappingInt32{isn + 2}}.with_win(1000));
+            test.execute(ExpectState{TCPSenderStateSummary::SYN_SENT});
+        }
+
         /* remove requirement to send corrective ACK for bad ACK
             {
                 TCPConfig cfg;


### PR DESCRIPTION
Added a unit test for lab3 to test for the sender ignoring anunacceptable ACK.

There was a bug in my `tcp_sender` that wasn't detected until lab4. Hopefully this test help future students find similar bugs during lab3.

In lab4, fsm_ack_rst_relaxed.cc surfaced this bug:
<img width="909" alt="Screen Shot 2020-10-24 at 3 09 07 PM" src="https://user-images.githubusercontent.com/8939148/97091593-ed33a180-160a-11eb-822c-7d4e75f906fb.png">