### PR TITLE
Added unit test for segment accepted but some bytes are kept

### DIFF
--- a/tests/fsm_stream_reassembler_cap.cc
+++ b/tests/fsm_stream_reassembler_cap.cc
@@ -45,6 +45,18 @@ int main() {
         }
 
         {
+            ReassemblerTestHarness test{2};
+            
+            test.execute(SubmitSegment{"bc", 1});
+            test.execute(BytesAssembled(0));
+
+            test.execute(SubmitSegment{"a", 0});
+            test.execute(BytesAssembled(2));
+            
+            test.execute(BytesAvailable("ab"));
+        }
+
+        {
             ReassemblerTestHarness test{1};
 
             test.execute(SubmitSegment{"ab", 0});


### PR DESCRIPTION
This case is from Lab2-`recv_windows.cc`. 

There was a bug in my `StreamReassembler(lab1)` that wasn't detected until lab2. Hopefully this test help future students find similar bugs during lab1.

I am sorry that I didn't take any screenshots.
My program returns only 'a' but not 'ab', but it has passed all the cases in the lab1 tests.
