### PR TITLE
Add a test in Lab1

### DIFF
--- a/tests/fsm_stream_reassembler_cap.cc
+++ b/tests/fsm_stream_reassembler_cap.cc
@@ -73,6 +73,28 @@ int main() {
             }
         }
 
+        {
+            ReassemblerTestHarness test{8};
+
+            test.execute(SubmitSegment{"a", 0});
+            test.execute(BytesAssembled(1));
+            test.execute(BytesAvailable("a"));
+            test.execute(NotAtEof{});
+
+            test.execute(SubmitSegment{"bc", 1});
+            test.execute(BytesAssembled(3));
+            test.execute(NotAtEof{});
+
+            test.execute(SubmitSegment{"ghX", 6}.with_eof(true));
+            test.execute(BytesAssembled(3));
+            test.execute(NotAtEof{});
+
+            test.execute(SubmitSegment{"cdefg", 2});
+            test.execute(BytesAssembled(9));
+            test.execute(BytesAvailable{"bcdefghX"});
+            test.execute(AtEof{});
+        }
+
     } catch (const exception &e) {
         cerr << "Exception: " << e.what() << endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
This case can check frist unassembled tag's move.
This case is used to determine whether some boundary conditions for detecting eof markers in Lab1 meet our expectations.

When I implemented Lab1, I found that the following code to judge the boundary condition of eof can pass all the tests, but in fact this code is wrong.

`if (_block.eof && _block.index + _block.data.length() <= _capacity)`

This test case is to hack this solution.